### PR TITLE
Workaround for Windows

### DIFF
--- a/ds4-calibration-tool.py
+++ b/ds4-calibration-tool.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
     wait_for_device()
 
     # Detach kernel driver
-    if dev.is_kernel_driver_active(0):
+    if sys.platform != 'win32' and dev.is_kernel_driver_active(0):
         try:
             dev.detach_kernel_driver(0)
         except usb.core.USBError as e:

--- a/ds4-tool.py
+++ b/ds4-tool.py
@@ -27,7 +27,7 @@ class DS4:
     def __init__(self):
         self.device_id = self.DEV_ID_JEDI
         self.wait_for_device(self.device_id)
-        if self.__dev.is_kernel_driver_active(0):
+        if sys.platform != 'win32' and self.__dev.is_kernel_driver_active(0):
             try:
                 self.__dev.detach_kernel_driver(0)
             except usb.core.USBError as e:


### PR DESCRIPTION
Workaround to fix the `NotImplementedError: is_kernel_driver_active` error on Windows OS. Tested on Win7x32 and Win11x64, Python 3.8.10 (32).